### PR TITLE
removed redundant css import (issue #1)

### DIFF
--- a/CahyaRealEstate/templates/CahyaRealEstate/home.html
+++ b/CahyaRealEstate/templates/CahyaRealEstate/home.html
@@ -19,7 +19,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <script src="https://kit.fontawesome.com/f8dced6eec.js" crossorigin="anonymous"></script>
 
-    <link rel="stylesheet" href="{% static 'CahyaRealEstate/lenis.css' %}">
     <link rel="stylesheet" href="{% static 'CahyaRealEstate/home.css' %}">
     <link rel="stylesheet" href="{% static 'CahyaRealEstate/animations.css'  %}">
     


### PR DESCRIPTION
As per issue #1, the redundant css import of **lenis.css** has been removed, preventing any possible bugs in the future.